### PR TITLE
allow zero buffer for zaptec blueprint

### DIFF
--- a/zaptec/charger-balancing-blueprint.yaml
+++ b/zaptec/charger-balancing-blueprint.yaml
@@ -66,7 +66,7 @@ blueprint:
       default: 2
       selector:
         number:
-          min: 1
+          min: 0
           max: 5
           unit_of_measurement: "A"
     input_charger_fuse:
@@ -84,7 +84,7 @@ blueprint:
       default: 1
       selector:
         number:
-          min: 1
+          min: 0
           max: 5
           unit_of_measurement: "A"
 trigger:


### PR DESCRIPTION
Nice job, tested it a bit and it seems to work great :)

One of my phases are heavily used now during the winter sometimes I might have exactly 6A available on that phase for a long time, so I would like to be able to charge during this time. My fuses can withstand a bit of overconsumption a few minutes so no real problem if it goes over a little bit for ~20 seconds.