### PR TITLE
Update charger_state to use native zaptec values to support hacs v0.8

### DIFF
--- a/zaptec/README.md
+++ b/zaptec/README.md
@@ -29,7 +29,11 @@ Note: A 3-phase charger is _not_ capable of consuming different levels on the th
 
 - You need a Zaptec charger
 
-- You need the [Zaptec integration](https://github.com/custom-components/zaptec), minimum version 0.7.0
+- You need the [Zaptec integration](https://github.com/custom-components/zaptec), minimum version 0.8.2
+  - If your Zaptec integration is not set up with the default English entity names or you have manually edited your entity ids, you need to ensure the following entity ids are present (see [this issue](https://github.com/svenakela/ha/issues/9#issuecomment-2907885636) for further details):
+    - `number.<your_installation_device>_available_current`
+    - `binary_sensor.<your_installation_device>_installation`
+    - `sensor.<your_charger_device>_charger_mode`
 
 - You need a P1/HAN meter connected to your home assistant. Minimum pushing current (A) for each phase
   - Tested devices from [Remne](https://remne.tech/) and [Smart Gateways](https://smartgateways.nl/en/product/smart-meter-wifi-gateway/)

--- a/zaptec/charger-balancing-blueprint.yaml
+++ b/zaptec/charger-balancing-blueprint.yaml
@@ -9,7 +9,7 @@ blueprint:
   
     - Most important is, you need to understand what you are into before using this blueprint!
   
-    - You need the Zaptec integration minimum version 0.8.0
+    - You need the Zaptec integration minimum version 0.8.2
   
     - You need a local HAN meter or similar power meter feed into your Home Assistant
   

--- a/zaptec/charger-balancing-blueprint.yaml
+++ b/zaptec/charger-balancing-blueprint.yaml
@@ -99,15 +99,14 @@ action:
     _charger_fuse: !input input_charger_fuse
     _safe_buffer: !input input_safe_buffer 
     _charger_safe_buffer: !input input_charger_safe_buffer
+    my_device_id: '{{ integration_entities(''zaptec'') | first | device_id }}'
     number_avail_curr: '{{ integration_entities(''zaptec'') | select(''match'', ''number.*available_current'') | first }}'
     sensor_charger_mode: '{{ integration_entities(''zaptec'') | select(''match'', ''sensor.*_charger_mode'') | first }}'
     binary_sensor_installation: '{{ integration_entities(''zaptec'') | select(''match'', ''binary_sensor.*_installation'') | first }}'
-- service: number.set_value
-  metadata: {}
-  target:
-    entity_id: '{{ number_avail_curr }}'
+- service: zaptec.limit_current
   data:
-    value: >-
+    device_id: '{{ my_device_id }}'
+    available_current: >-
       {% set main_fuse       = _main_fuse|float(0.0) %}
       {% set charger_fuse    = _charger_fuse|float(0.0) %}
       {% set safe_buffer     = _safe_buffer|float(2.0) %}

--- a/zaptec/charger-balancing-blueprint.yaml
+++ b/zaptec/charger-balancing-blueprint.yaml
@@ -99,14 +99,15 @@ action:
     _charger_fuse: !input input_charger_fuse
     _safe_buffer: !input input_safe_buffer 
     _charger_safe_buffer: !input input_charger_safe_buffer
-    my_device_id: '{{ integration_entities(''zaptec'') | first | device_id }}'
     number_avail_curr: '{{ integration_entities(''zaptec'') | select(''match'', ''number.*available_current'') | first }}'
     sensor_charger_mode: '{{ integration_entities(''zaptec'') | select(''match'', ''sensor.*_charger_mode'') | first }}'
     binary_sensor_installation: '{{ integration_entities(''zaptec'') | select(''match'', ''binary_sensor.*_installation'') | first }}'
-- service: zaptec.limit_current
+- service: number.set_value
+  metadata: {}
+  target:
+    entity_id: '{{ number_avail_curr }}'
   data:
-    device_id: '{{ my_device_id }}'
-    available_current: >-
+    value: >-
       {% set main_fuse       = _main_fuse|float(0.0) %}
       {% set charger_fuse    = _charger_fuse|float(0.0) %}
       {% set safe_buffer     = _safe_buffer|float(2.0) %}

--- a/zaptec/charger-balancing-blueprint.yaml
+++ b/zaptec/charger-balancing-blueprint.yaml
@@ -125,7 +125,7 @@ action:
       {% set prio = 666 %}
       
       {# Priority limiting #}
-      {% if charger_state == 'Charging' %}
+      {% if charger_state == 'Connected_Charging' %}
         {# Are we about to blow a fuse? #}
         {% if current > main_fuse or charger_limit > charger_fuse %}
           {% set main_max = (charger_limit - (current - main_fuse))|int %}
@@ -137,15 +137,15 @@ action:
       {% endif %}
       
       {# Ordinary limiting #}
-      {% if (charger_state == 'Charging' and updates_ok)
-          or charger_state == 'Waiting' %}
+      {% if (charger_state == 'Connected_Charging' and updates_ok)
+          or charger_state == 'Connected_Requesting' %}
         {# Been zeroed and need to restart when main_fuse allows #}
         {% set _max_pow = limit + (main_safe_level - current)|int %}
         {% set _no_pow  = 0 if _max_pow < min_start_limit else 666 %}
         {% set limit = [_no_pow, _max_pow, charger_safe_level]|min %}
       {% endif %}
       
-      {% if charger_state == 'Charge done' 
+      {% if charger_state == 'Connected_Finished' 
          or charger_state == 'Disconnected' 
          or charger_state == 'Unknown' %}
         {# We are not charging, go to zero #}

--- a/zaptec/charger-balancing-blueprint.yaml
+++ b/zaptec/charger-balancing-blueprint.yaml
@@ -9,7 +9,7 @@ blueprint:
   
     - Most important is, you need to understand what you are into before using this blueprint!
   
-    - You need the Zaptec integration minimum version 0.7.0
+    - You need the Zaptec integration minimum version 0.8.0
   
     - You need a local HAN meter or similar power meter feed into your Home Assistant
   
@@ -125,7 +125,7 @@ action:
       {% set prio = 666 %}
       
       {# Priority limiting #}
-      {% if charger_state == 'Connected_Charging' %}
+      {% if charger_state == 'connected_charging' %}
         {# Are we about to blow a fuse? #}
         {% if current > main_fuse or charger_limit > charger_fuse %}
           {% set main_max = (charger_limit - (current - main_fuse))|int %}
@@ -137,17 +137,17 @@ action:
       {% endif %}
       
       {# Ordinary limiting #}
-      {% if (charger_state == 'Connected_Charging' and updates_ok)
-          or charger_state == 'Connected_Requesting' %}
+      {% if (charger_state == 'connected_charging' and updates_ok)
+          or charger_state == 'connected_requesting' %}
         {# Been zeroed and need to restart when main_fuse allows #}
         {% set _max_pow = limit + (main_safe_level - current)|int %}
         {% set _no_pow  = 0 if _max_pow < min_start_limit else 666 %}
         {% set limit = [_no_pow, _max_pow, charger_safe_level]|min %}
       {% endif %}
       
-      {% if charger_state == 'Connected_Finished' 
-         or charger_state == 'Disconnected' 
-         or charger_state == 'Unknown' %}
+      {% if charger_state == 'connected_finished' 
+         or charger_state == 'disconnected' 
+         or charger_state == 'unknown' %}
         {# We are not charging, go to zero #}
         {% set limit = 0 %}
       {% endif %}


### PR DESCRIPTION
The Zaptec Custom component for HA v0.8 will migrate to use the zaptec native names for the charger state (see https://github.com/custom-components/zaptec/pull/215 for details).

This should not be merged until 0.8.0 is released