### PR TITLE
Extend charger fuse limit range to 6..32A

### DIFF
--- a/zaptec/charger-balancing-blueprint.yaml
+++ b/zaptec/charger-balancing-blueprint.yaml
@@ -75,8 +75,8 @@ blueprint:
       default: 16
       selector:
         number:
-          min: 12
-          max: 25
+          min: 6
+          max: 32
           unit_of_measurement: "A"
     input_charger_safe_buffer:
       name: Current Limit Charger Safe Buffer


### PR DESCRIPTION
According to https://www.calameo.com/alma-solar/read/0050641541114ba3bc244 (page 13), the current can be limited on the charger to 6 to 32A.